### PR TITLE
話題削除機能

### DIFF
--- a/app/controllers/past_topics_controller.rb
+++ b/app/controllers/past_topics_controller.rb
@@ -9,6 +9,11 @@ class PastTopicsController < ApplicationController
     render json: { new_past_topic: new_past_topic }
   end
 
+  def destroy
+    delete_past_topic = PastTopic.find(params[:id])
+    delete_past_topic.destroy
+  end
+
   private
   
   def past_topic_params

--- a/app/javascript/delete-topic.js
+++ b/app/javascript/delete-topic.js
@@ -4,7 +4,11 @@ const deleteTopic = () => {
   delete_topic_btns.forEach((delete_topic_btn) => {
     delete_topic_btn.addEventListener("click", function(){
       const topicId = this.getAttribute("data");
-      deleteData(csrfToken, topicId);
+      if (window.confirm(`話した事データ${topicId}（1件）を削除しますか？`)) {
+        deleteData(csrfToken, topicId);
+      } else {
+        return;
+      }
     });
   });
 };

--- a/app/javascript/delete-topic.js
+++ b/app/javascript/delete-topic.js
@@ -1,0 +1,27 @@
+const deleteTopic = () => {
+  const csrfToken = document.querySelector("meta[name='csrf-token']").content;
+  const delete_topic_btns = document.querySelectorAll(".delete_topic_btn");
+  delete_topic_btns.forEach((delete_topic_btn) => {
+    delete_topic_btn.addEventListener("click", function(){
+      const topicId = this.getAttribute("data");
+      deleteData(csrfToken, topicId);
+    });
+  });
+};
+
+const deleteData = (csrfToken, topicId) => {
+  const deleteTopicElement = document.getElementById(`past_topic_${topicId}`);
+  const formData = new FormData();
+  formData.set("authenticity_token", `${csrfToken}`);
+  const XHR = new XMLHttpRequest();
+  XHR.open("DELETE", `/past_topics/${topicId}`, true);
+  XHR.send(formData); // 削除リクエストの送信
+  XHR.onload = () => {
+    console.log(deleteTopicElement);
+    deleteTopicElement.remove();
+  };
+};
+
+window.addEventListener("load", deleteTopic);
+
+export { deleteData };

--- a/app/javascript/editpage-new-topic.js
+++ b/app/javascript/editpage-new-topic.js
@@ -1,4 +1,5 @@
 import { updateData } from "./update-topic";
+import { deleteData } from "./delete-topic";
 
 const newTopic = () => {
   const newTopicButton = document.getElementById("new_topic_btn");
@@ -23,16 +24,20 @@ const newData = (csrfToken, characterId) => {
   XHR.onload = () => {
     const newTopic = XHR.response.new_past_topic; // 新規フォームデータの取得
     const html = `
-    <form class="topic_form" data="${newTopic.id}" action="/past_topics/${newTopic.id}" accept-charset="UTF-8" method="post">
-      <input type="hidden" name="_method" value="patch">
-      <input type="hidden" name="authenticity_token" value="${csrfToken}">
-      <input value="${newTopic.created_date}" type="date" name="past_topic[created_date]" id="past_topic_created_date">              
-      <textarea class="new_past_topic_input" name="past_topic[past_topic]" id="past_topic_past_topic"></textarea>
-    </form>
-    `;
+    <div id="past_topic_${newTopic.id}">
+      <form class="topic_form" data="${newTopic.id}" action="/past_topics/${newTopic.id}" accept-charset="UTF-8" method="post">
+        <input type="hidden" name="_method" value="patch">
+        <input type="hidden" name="authenticity_token" value="${csrfToken}">
+        <input value="${newTopic.created_date}" type="date" name="past_topic[created_date]" id="past_topic_created_date">              
+        <textarea name="past_topic[past_topic]" id="new_past_topic_input_${newTopic.id}"></textarea>
+      </form>
+      <button type="button" id="delete_new_topic_btn_${newTopic.id}" data="${newTopic.id}">削除</button>
+    </div>
+    `; // newTopic.id同じモノを繰り返しすぎ・・・
   const pastTopics = document.getElementById("past_topics");
   pastTopics.insertAdjacentHTML("afterbegin", html); // 新規フォームをHTMLに挿入
   updateNewTopic(); //処理を外に出したい・・・（async/awaitあたり？）
+  deleteNewTopic(newTopic.id);
   };
 };
 
@@ -49,6 +54,12 @@ const updateNewTopic = () => {
         updateData(newPastTopicInput, "past_topics");
       });
     });
+const deleteNewTopic = (newTopicId) => {
+  const csrfToken = document.querySelector("meta[name='csrf-token']").content;
+  const delete_new_topic_btn = document.getElementById(`delete_new_topic_btn_${newTopicId}`);
+  delete_new_topic_btn.addEventListener("click", function(){
+    const topicId = this.getAttribute("data");
+    deleteData(csrfToken, topicId);
   });
 };
 

--- a/app/javascript/editpage-new-topic.js
+++ b/app/javascript/editpage-new-topic.js
@@ -36,24 +36,24 @@ const newData = (csrfToken, characterId) => {
     `; // newTopic.id同じモノを繰り返しすぎ・・・
   const pastTopics = document.getElementById("past_topics");
   pastTopics.insertAdjacentHTML("afterbegin", html); // 新規フォームをHTMLに挿入
-  updateNewTopic(); //処理を外に出したい・・・（async/awaitあたり？）
+  updateNewTopic(newTopic.id); //処理を外に出したい・・・（async/awaitあたり？）
   deleteNewTopic(newTopic.id);
   };
 };
 
-const updateNewTopic = () => {
-  const newPastTopicInputs = document.querySelectorAll(".new_past_topic_input");
-
-  newPastTopicInputs.forEach(function(newPastTopicInput){
-    newPastTopicInput.addEventListener("blur", function(e){
+const updateNewTopic = (newTopicId) => {
+  const newPastTopicInput = document.getElementById(`new_past_topic_input_${newTopicId}`);
+  newPastTopicInput.addEventListener("blur", function(e){
+    updateData(newPastTopicInput, "past_topics");
+  });
+  newPastTopicInput.addEventListener("focus", function(){
+    console.log("OK");
+    window.addEventListener("beforeunload", function(e){
       updateData(newPastTopicInput, "past_topics");
     });
-    newPastTopicInput.addEventListener("focus", function(){
-      console.log("OK");
-      window.addEventListener("beforeunload", function(e){
-        updateData(newPastTopicInput, "past_topics");
-      });
-    });
+  });
+};
+
 const deleteNewTopic = (newTopicId) => {
   const csrfToken = document.querySelector("meta[name='csrf-token']").content;
   const delete_new_topic_btn = document.getElementById(`delete_new_topic_btn_${newTopicId}`);

--- a/app/javascript/editpage-new-topic.js
+++ b/app/javascript/editpage-new-topic.js
@@ -59,7 +59,11 @@ const deleteNewTopic = (newTopicId) => {
   const delete_new_topic_btn = document.getElementById(`delete_new_topic_btn_${newTopicId}`);
   delete_new_topic_btn.addEventListener("click", function(){
     const topicId = this.getAttribute("data");
-    deleteData(csrfToken, topicId);
+    if (window.confirm(`話した事データ${topicId}（1件）を削除しますか？`)) {
+      deleteData(csrfToken, topicId);
+    } else {
+      return;
+    }
   });
 };
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,8 @@ require("channels")
 require("edit-data")
 require("update-topic")
 require("editpage-new-topic")
+require("delete-topic")
+
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/javascript/update-topic.js
+++ b/app/javascript/update-topic.js
@@ -1,6 +1,6 @@
 const updateTopic = () => {
   const pastTopicInputs = document.querySelectorAll(".past_topic_input");
-  const futureTopicInputs = document.querySelectorAll(".future_topic_input");
+  const futureTopicInputs = document.querySelectorAll(".future_topic_input"); //getElementByIdで取得したい
   pastTopicInputs.forEach(function(pastTopicInput){
     pastTopicInput.addEventListener("blur", function(e){
       updateData(pastTopicInput, "past_topics");

--- a/app/views/characters/_main_view_edit.html.erb
+++ b/app/views/characters/_main_view_edit.html.erb
@@ -44,11 +44,9 @@
       <% end %>
 
       <div class="edit_topic_form">
-        <%= form_with model: @latest_future_topic, class: "edit_future_topic", local: true do |f| %>
-          <div class='field'>
-            話したい事<br>
-            <%= f.text_area :future_topic %>
-          </div>
+        <%= form_with model: @latest_future_topic, class: "edit_future_topic", data: @latest_future_topic.id, local: true do |f| %><%# class指定が適当になっている %>
+          話したい事<br>
+          <%= f.text_area :future_topic, class: "topic_input future_topic_input" %>
         <% end %>
 
         <div class="edit_past_topic">
@@ -56,10 +54,13 @@
             話した事<br>
           <div id="past_topics">
             <% @past_topics.each do |past_topic| %>
-              <%= form_with model: past_topic, class: "topic_form", data: past_topic.id, local: true do |f| %>
-                  <%= f.date_field :created_date %>              
-                  <%= f.text_area :past_topic, class: "past_topic_input" %>
-              <% end %>
+              <div id="past_topic_<%= past_topic.id %>">
+                <%= form_with model: past_topic, class: "topic_form", data: past_topic.id, local: true do |f| %>
+                    <%= f.date_field :created_date %>              
+                    <%= f.text_area :past_topic, class: "past_topic_input" %>
+                <% end %>
+                <button type="button" class="delete_topic_btn" data="<%= past_topic.id %>">削除</button>
+              </div>
             <% end %>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   root to: "characters#index"
   resources :users, only: [:edit, :update]
   resources :characters
-  resources :past_topics, only: [:update, :create]
+  resources :past_topics, only: [:update, :create, :destroy]
   resources :future_topics, only: :update
 end


### PR DESCRIPTION
# What
- past_topics#destroyアクションの作成
- character/editビューの編集（削除ボタンの追加）
- delete-topic.jsで削除ボタン処理（Ajax通信によるDELETEリクエスト送信、フォーム削除）の作成
- editpage-new-topic.jsで削除ボタン処理の作成
- 削除確認処理の追加

#Why
- 話題削除機能の実装のため