### PR TITLE
話題削除機能（トップページ）

### DIFF
--- a/app/controllers/past_topics_controller.rb
+++ b/app/controllers/past_topics_controller.rb
@@ -12,11 +12,19 @@ class PastTopicsController < ApplicationController
   def destroy
     delete_past_topic = PastTopic.find(params[:id])
     delete_past_topic.destroy
+
+    character = Character.find(character_id_params)
+    latest_past_topic = character.past_topics.order(created_date: :DESC).order(id: :DESC)[0]
+    render json: { latest_past_topic: latest_past_topic }
   end
 
   private
-  
+
   def past_topic_params
     params.require(:past_topic).permit(:past_topic, :created_date, :character_id)
+  end
+
+  def character_id_params
+    params.require(:character_id)
   end
 end

--- a/app/javascript/indexpage-delete-topic.js
+++ b/app/javascript/indexpage-delete-topic.js
@@ -1,3 +1,4 @@
+import { updateData } from "./update-topic";
 
 const deleteTopic = () => {
   const csrfToken = document.querySelector("meta[name='csrf-token']").content;
@@ -40,6 +41,21 @@ const deleteData = (csrfToken, characterId, topicId) => {
       </form>            
     `; // newTopic.id同じモノを繰り返しすぎ・・・
     pastTopic.insertAdjacentHTML("afterbegin", html); // 新規フォームをHTMLに挿入
+    updateLatestTopic(latestTopic.id); //処理を外に出したい・・・（async/awaitあたり？）
   };
 };
+
+const updateLatestTopic = (latestTopicId) => {
+  const latestPastTopicInput = document.getElementById(`latest_past_topic_input_${latestTopicId}`);
+  latestPastTopicInput.addEventListener("blur", function(e){
+    updateData(latestPastTopicInput, "past_topics");
+  });
+  latestPastTopicInput.addEventListener("focus", function(){
+    console.log("OK");
+    window.addEventListener("beforeunload", function(e){ // 削除やnewの後に更新するとエラーが出やすい。恐らくnullになるから。
+      updateData(latestPastTopicInput, "past_topics");
+    });
+  });
+};
+
 window.addEventListener("load", deleteTopic);

--- a/app/javascript/indexpage-delete-topic.js
+++ b/app/javascript/indexpage-delete-topic.js
@@ -1,0 +1,45 @@
+
+const deleteTopic = () => {
+  const csrfToken = document.querySelector("meta[name='csrf-token']").content;
+  const delete_topic_btns = document.querySelectorAll(".index_delete_topic_btn");
+  delete_topic_btns.forEach((delete_topic_btn) => {
+    delete_topic_btn.addEventListener("click", function(){
+      const latestPastTopicId = this.parentElement.querySelector(".topic_form").getAttribute("data");
+      const characterId = this.getAttribute("data-character_id");
+      console.log("OK");
+      if (window.confirm(`編集中の話した事データ（1件）を削除しますか？`)) {
+        deleteData(csrfToken, characterId, latestPastTopicId);
+      } else {
+        return;
+      }
+    });
+  });
+};
+
+const deleteData = (csrfToken, characterId, topicId) => {
+  const formData = new FormData();
+  formData.set("authenticity_token", `${csrfToken}`);
+  formData.set("character_id", `${characterId}`);
+  const XHR = new XMLHttpRequest();
+  XHR.open("DELETE", `/past_topics/${topicId}`, true);
+  XHR.responseType = "json";
+  XHR.send(formData); // 削除リクエストの送信
+  XHR.onload = () => {
+    const pastTopic = document.getElementById(`past_topic_${characterId}`);
+    pastTopic.querySelector(".topic_form").remove();
+    console.log("OK");
+    // 既存のtopic_formを削除
+    const latestTopic = XHR.response.latest_past_topic; // 新規フォームデータの取得
+    console.log(latestTopic);
+    const html = `
+      <form class="topic_form" data="${latestTopic.id}" action="/past_topics/${latestTopic.id}" accept-charset="UTF-8" method="post">
+        <input type="hidden" name="_method" value="patch"><input type="hidden" name="authenticity_token" value="${csrfToken}">
+        <input value="${characterId}" type="hidden" name="past_topic[character_id]" id="past_topic_character_id">
+        <input class="created_date" value="${latestTopic.created_date}" type="date" name="past_topic[created_date]" id="past_topic_created_date">
+        <textarea class="topic_input past_topic_input" name="past_topic[past_topic]" id="latest_past_topic_input_${latestTopic.id}">${latestTopic.past_topic}</textarea>
+      </form>            
+    `; // newTopic.id同じモノを繰り返しすぎ・・・
+    pastTopic.insertAdjacentHTML("afterbegin", html); // 新規フォームをHTMLに挿入
+  };
+};
+window.addEventListener("load", deleteTopic);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -12,6 +12,7 @@ require("update-topic")
 require("editpage-new-topic")
 require("delete-topic")
 require("indexpage-new-topic")
+require("indexpage-delete-topic")
 
 
 

--- a/app/views/characters/_main_view_index.html.erb
+++ b/app/views/characters/_main_view_index.html.erb
@@ -52,6 +52,7 @@
               <% end %>
             <% end %>
             <button type="button" class="index_new_topic_btn" data-character_id="<%= character.id %>">new</button>
+            <button type="button" class="index_delete_topic_btn" data-character_id="<%= character.id %>">削除</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# What
- characters/indexビューの編集（newボタンの追加）
- past_topics#destroyアクションの編集
- indexpage-delete-topic.jsに削除ボタン処理（Ajax通信によるDELETEリクエスト送信、既存フォーム削除、新規フォーム追加）を作成
- indexpage-delete-topic.jsに追加したフォームの更新処理を追加

# Why
- 話題削除機能（トップページ）の実装のため