### PR TITLE
新規トピック削除時のJSエラー解消

### DIFF
--- a/app/controllers/past_topics_controller.rb
+++ b/app/controllers/past_topics_controller.rb
@@ -13,9 +13,11 @@ class PastTopicsController < ApplicationController
     delete_past_topic = PastTopic.find(params[:id])
     delete_past_topic.destroy
 
-    character = Character.find(character_id_params)
-    latest_past_topic = character.past_topics.order(created_date: :DESC).order(id: :DESC)[0]
-    render json: { latest_past_topic: latest_past_topic }
+    if params[:character_id] #indexpage-delete-topic.jsから来たリクエストの処理
+      character = Character.find(character_id_params)
+      latest_past_topic = character.past_topics.order(created_date: :DESC).order(id: :DESC)[0]
+      render json: { latest_past_topic: latest_past_topic }
+    end
   end
 
   private

--- a/app/javascript/delete-topic.js
+++ b/app/javascript/delete-topic.js
@@ -21,7 +21,6 @@ const deleteData = (csrfToken, topicId) => {
   XHR.open("DELETE", `/past_topics/${topicId}`, true);
   XHR.send(formData); // 削除リクエストの送信
   XHR.onload = () => {
-    console.log(deleteTopicElement);
     deleteTopicElement.remove();
   };
 };


### PR DESCRIPTION
# What
- past_topics#destroyアクションに条件分岐設定

# Why
- 新規トピック削除時のJSエラー解消のため