### PR TITLE
キャラクター削除時の確認機能

### DIFF
--- a/app/views/categories/_main_view_index.html.erb
+++ b/app/views/categories/_main_view_index.html.erb
@@ -29,7 +29,7 @@
           <div class="character_name"><%= character.name %></div>
           <div class="detail">
             <%= link_to("詳細編集", edit_character_path(character)) %><br>
-            <%= link_to("データ削除", character_path(character), method: :delete) %>
+            <%= link_to("データ削除", character_path(character), method: :delete, data: {confirm: "「#{character.name}」のデータを削除してもよろしいですか？"}) %>
           </div>
         </div>
         <div class="character_topic">

--- a/app/views/categories/_main_view_show.html.erb
+++ b/app/views/categories/_main_view_show.html.erb
@@ -30,7 +30,7 @@
           <div class="character_name"><%= character.name %></div>
           <div class="detail">
             <%= link_to("詳細編集", edit_character_path(character)) %><br>
-            <%= link_to("データ削除", character_path(character), method: :delete) %>
+            <%= link_to("データ削除", character_path(character), method: :delete, data: {confirm: "「#{character.name}」のデータを削除してもよろしいですか？"}) %>
           </div>
         </div>
         <div class="character_topic">

--- a/app/views/characters/_main_view_character_edit.html.erb
+++ b/app/views/characters/_main_view_character_edit.html.erb
@@ -55,7 +55,7 @@
         <div class='actions'>
           <%= f.submit "更新", class: 'btn'%>
         </div>
-        <%= link_to("データ削除", character_path(@character), method: :delete) %>
+        <%= link_to("データ削除", character_path(@character), method: :delete, data: {confirm: "「#{@character.name}」のデータを削除してもよろしいですか？"}) %>
       <% end %>
 
       <div class="edit_topic_form">


### PR DESCRIPTION
# What
- categories/index、categories/show、characters/editビューのlink_toメソッドに削除確認オプション追加

# Why
- キャラクター削除時の確認機能の実装のため