### PR TITLE
日付バリデーションの削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 | Column       | Type       | Options                        |
 | ------------ | ---------- | ------------------------------ |
 | past_topic   | text       |                                |
-| created_date | date       | null: false                    |
+| created_date | date       |                                |
 | character_id | references | null: false, foreign_key: true |
 
 ### Association

--- a/app/models/character_topic.rb
+++ b/app/models/character_topic.rb
@@ -2,10 +2,7 @@ class CharacterTopic
   include ActiveModel::Model
   attr_accessor :name, :image, :url, :describe, :past_topic, :created_date, :future_topic, :user_id, :category_ids
 
-  with_options presence: true do
-    validates :name
-    validates :created_date
-  end
+  validates :name, presence: true
 
   def save
     character = Character.create(name: name, url: url, describe: describe, image: image, user_id: user_id, category_ids: category_ids)

--- a/app/models/past_topic.rb
+++ b/app/models/past_topic.rb
@@ -1,5 +1,3 @@
 class PastTopic < ApplicationRecord
   belongs_to :character
-
-  validates :created_date, presence: true
 end

--- a/db/migrate/20220621044321_create_past_topics.rb
+++ b/db/migrate/20220621044321_create_past_topics.rb
@@ -2,7 +2,7 @@ class CreatePastTopics < ActiveRecord::Migration[6.0]
   def change
     create_table :past_topics do |t|
       t.text       :past_topic
-      t.date       :created_date, null: false
+      t.date       :created_date
       t.references :character, null: false, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(version: 2022_06_29_031954) do
 
   create_table "past_topics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "past_topic"
-    t.date "created_date", null: false
+    t.date "created_date"
     t.bigint "character_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
# What
- past_topicsテーブルnull: false削除
- CharacterTopicモデルバリデーション編集
- PastTopicモデルバリデーション編集

# Why
- 日付バリデーションの削除のため