### PR TITLE
キャラクター編集ページのエラー改修

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -25,6 +25,8 @@ class CharactersController < ApplicationController
     if @character.update(character_params)
       redirect_to root_path
     else
+      @latest_future_topic = @character.future_topics[0]
+      @past_topics = @character.past_topics.order(created_date: :DESC).order(id: :DESC)
       render :edit
     end
   end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -6,4 +6,6 @@ class Character < ApplicationRecord
   has_many :future_topics, dependent: :destroy
   has_many :character_categories, dependent: :destroy
   has_many :categories, through: :character_categories
+
+  validates :name, presence: true
 end

--- a/app/views/characters/_main_view_character_edit.html.erb
+++ b/app/views/characters/_main_view_character_edit.html.erb
@@ -19,7 +19,11 @@
       <%= form_with model: @character, local: true, class: "edit_profile_form" do |f|%>
         <%= render "shared/error_messages", model: f.object %>
         <div class='image'>
-          <%= image_tag @character.image, id: "selected_character_image" %>
+          <% if @character.image.attached? %>
+            <%= image_tag @character.image, id: "selected_character_image" %>
+          <% else %>
+            <%= image_tag "no_image.png", id: "selected_character_image" %>
+          <% end %>
           <%= f.file_field :image, id:"character_image" %>
         </div>
         <div class='field'>


### PR DESCRIPTION
# What
- characters/editビューのimage表示に条件分岐を追加
- Characterモデルにバリデーション追加
- characters#updateアクションにバリデーションエラー後の処理を追加

# Why
- キャラクター編集ページでのimageがない場合のエラーの改修のため
- キャラクター編集ページから、キャラクター名が空でのデータ更新を拒否するため