### PR TITLE
未ログイン時のエラー改修

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,4 +1,5 @@
 class CategoriesController < ApplicationController
+  before_action :set_categories
 
   def index
     @characters = current_user.characters
@@ -48,5 +49,9 @@ class CategoriesController < ApplicationController
   
   def category_params
     params.require(:category).permit(:name, :describe, character_ids: []).merge(user_id: current_user.id)
+  end
+
+  def set_categories
+    @categories = current_user.categories
   end
 end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -1,5 +1,6 @@
 class CharactersController < ApplicationController
-  before_action :authenticate_user!
+  before_action :set_categories
+
   def new
     @character_topic = CharacterTopic.new
   end
@@ -45,5 +46,9 @@ class CharactersController < ApplicationController
 
   def character_topic_params
     params.require(:character_topic).permit(:name, :image, :url, :describe, :past_topic, :created_date, :future_topic, category_ids: []).merge(user_id: current_user.id)
+  end
+
+  def set_categories
+    @categories = current_user.categories
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,4 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!
-
   def edit
   end
 


### PR DESCRIPTION
# What
- authenticate_userメソッドの設置変更
- set_categoriesメソッドの設置変更

# Why
- 未ログイン時に発生する「current_userがnil」であるというエラーの改修
applicationsコントローラーでset_categoriesメソッドを定義していたことが原因のため、設置場所を各コントローラーへ変更。