### PR TITLE
キャラクターソート機能

### DIFF
--- a/app/assets/stylesheets/characters.css
+++ b/app/assets/stylesheets/characters.css
@@ -24,6 +24,13 @@
 
 .side_bar_top {
   height: 100px;
+  width: 100%;
+}
+
+.main_logo {
+  margin: 20px auto;
+  width: 80%;
+  font-size: 36px;
 }
 
 /* サイドバーコンテンツ */
@@ -44,16 +51,36 @@
   justify-content: space-between;
 }
 
+.sort_menu {
+  padding: 8px 20px;
+  background-color: rgb(243, 243, 243);
+}
+
+.sort_btn {
+  display: inline-block;
+  background-color: #c898c9;
+  padding: 3px 10px;
+  color: #fff;
+}
+
+.active {
+  background-color: #4A154B;
+}
+
 .main_top a {
   color: #fff;
 }
 
+
+
 /* メインコンテンツ */
 .main_contents {
-  padding: 50px 0;
-  height: calc(100vh - 100px);
+  padding: 20px 0 50px;
+  height: calc(100vh - 146px);
   overflow: auto;
+  position: relative;
 }
+
 
 .main_contents_wrapper {
   margin: 0 auto;

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,11 +2,17 @@ class CategoriesController < ApplicationController
   before_action :set_categories
 
   def index
-    @characters = current_user.characters
+    # @characters = current_user.characters
+    
+    if params[:sort] == "updated_at"
+      @characters = Character.order_updated_at(current_user.id) #updated_at順
+    else
+      @characters = Character.order_past_topic(current_user.id) #past_topic順（デフォルト）
+    end
   end
 
   def new
-    @characters = current_user.characters
+    @characters = Character.where(user_id: current_user.id).order(name: :asc)
     @category = Category.new
   end
 
@@ -22,12 +28,18 @@ class CategoriesController < ApplicationController
 
   def show
     @category = Category.find(params[:id])
-    @characters = @category.characters
+    # @characters = @category.characters
+
+    if params[:sort] == "updated_at"
+      @characters = Character.category_order_updated_at(@category.id) #updated_at順
+    else
+      @characters = Character.category_order_past_topic(@category.id) #past_topic順（デフォルト）
+    end
   end
 
   def edit
     @category = Category.find(params[:id])
-    @characters = current_user.characters
+    @characters = Character.where(user_id: current_user.id).order(name: :asc)
   end
 
   def update

--- a/app/controllers/future_topics_controller.rb
+++ b/app/controllers/future_topics_controller.rb
@@ -2,6 +2,9 @@ class FutureTopicsController < ApplicationController
   def update
     latest_future_topic = FutureTopic.find(params[:id])
     latest_future_topic.update(future_topic_params)
+    if latest_future_topic.saved_changes?
+      latest_future_topic.character.touch
+    end
   end
 
   private

--- a/app/controllers/past_topics_controller.rb
+++ b/app/controllers/past_topics_controller.rb
@@ -2,16 +2,21 @@ class PastTopicsController < ApplicationController
   def update
     latest_past_topic = PastTopic.find(params[:id])
     latest_past_topic.update(past_topic_params)
+    if latest_past_topic.saved_changes?
+      latest_past_topic.character.touch
+    end
   end
 
   def create
     new_past_topic = PastTopic.create(past_topic_params)
+    new_past_topic.character.touch
     render json: { new_past_topic: new_past_topic }
   end
 
   def destroy
     delete_past_topic = PastTopic.find(params[:id])
     delete_past_topic.destroy
+    delete_past_topic.character.touch
 
     if params[:character_id] #indexpage-delete-topic.jsから来たリクエストの処理
       character = Character.find(character_id_params)

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -8,4 +8,23 @@ class Character < ApplicationRecord
   has_many :categories, through: :character_categories
 
   validates :name, presence: true
+
+  scope :order_updated_at, -> (current_user_id) {where(user_id: current_user_id).order(updated_at: :desc)}
+  scope :order_past_topic, -> (current_user_id) {find_by_sql(
+    ["SELECT ch.*, MAX(p.created_date) FROM characters ch
+    INNER JOIN past_topics p ON p.character_id = ch.id
+    WHERE user_id = ?
+    GROUP BY p.character_id
+    ORDER BY max(p.created_date) DESC", current_user_id]
+  )}
+
+  scope :category_order_updated_at, -> (category_id) {joins(:character_categories).where(character_categories: { category_id: category_id }).order(updated_at: :desc)}
+  scope :category_order_past_topic, -> (category_id) {find_by_sql(
+    ["SELECT ch.*, MAX(p.created_date) FROM characters ch
+    INNER JOIN past_topics p ON p.character_id = ch.id
+    INNER JOIN character_categories ca ON ca.character_id = ch.id
+    WHERE ca.category_id = ?
+    GROUP BY p.character_id
+    ORDER BY max(p.created_date) DESC", category_id]
+  )}
 end

--- a/app/views/categories/_main_view_index.html.erb
+++ b/app/views/categories/_main_view_index.html.erb
@@ -16,6 +16,11 @@
   </div>
 </div>
 
+<div class="sort_menu">
+  <%= link_to "会話日付順", root_path, class: "sort_btn #{'active' unless params[:sort]}" %>
+  <%= link_to "入力更新順", root_path(sort: "updated_at"), class: "sort_btn #{'active' if params[:sort] == "updated_at"}" %>
+</div>
+
 <div class="main_contents">
   <div class="main_contents_wrapper">
     <% @characters.each do |character| %>

--- a/app/views/categories/_main_view_show.html.erb
+++ b/app/views/categories/_main_view_show.html.erb
@@ -17,6 +17,11 @@
   </div>
 </div>
 
+<div class="sort_menu">
+  <%= link_to "会話日付順", category_path, class: "sort_btn #{'active' unless params[:sort]}" %>
+  <%= link_to "入力更新順", category_path(sort: "updated_at"), class: "sort_btn #{'active' if params[:sort] == "updated_at"}" %>
+</div>
+
 <div class="main_contents">
   <div class="main_contents_wrapper">
     <% @characters.each do |character| %>


### PR DESCRIPTION
# What
- future_topics、past_topicsコントローラー編集
（レコードが更新されたら親モデルのcharacterインスタンスのレコードも更新するという処理を追加）
- Characterモデル編集
（characterインスタンスのupdated_atでソートするスコープを追加）
（past_topicsの最新のcreated_dateを元に親モデルのcharacterインスタンスをソートするスコープを追加）
- categoriesコントローラー編集
（GETリクエストのパラメーターによって呼び出すモデルのソート処理のスコープを切り替え）
（編集ページは50音順にソートする処理を追加）
- ビューにソートボタンを追加

# Why
キャラクターソート機能の実装のため